### PR TITLE
fixed MonacoLoader.js

### DIFF
--- a/src/MonacoLoader.js
+++ b/src/MonacoLoader.js
@@ -46,7 +46,7 @@ module.exports = {
         fn: onGotAmdLoader
       });
     } else {
-      if (typeof window.require === 'undefined') {
+      if (!window.require) {
         const loaderScript = window.document.createElement('script');
         loaderScript.type = 'text/javascript';
         loaderScript.src = loaderUrl;


### PR DESCRIPTION
if window.require is undefined,typeof window.require will be 'object',the judgment will be wrong.